### PR TITLE
Support not set ignroe_cves label

### DIFF
--- a/funcs.rb
+++ b/funcs.rb
@@ -30,7 +30,7 @@ def scan_image(image_name, image_remove: false)
   end
 
   image = Docker::Image.create('fromImage' => image_name)
-  ignore_cves = image.json.dig('Config', 'Labels', 'ignore_cves')&.split(/,\s?/)
+  ignore_cves = image.json.dig('Config', 'Labels', 'ignore_cves')&.split(/,\s?/) || []
   ignore_cves += config['ignore_cves'] || []
   File.open(ignore_path, mode = 'w') { |f| f.write(ignore_cves.join("\n")) }
 


### PR DESCRIPTION

When not set ignore_cves label then error. Fix it.

```
E, [2022-08-15T01:47:46.447085 #1370] ERROR -- : ***/******* happend error undefined method `+' for nil:NilClass

  ignore_cves += config['ignore_cves'] || []
              ^
```