### PR TITLE
Fix output file path when trivy exists

### DIFF
--- a/funcs.rb
+++ b/funcs.rb
@@ -56,6 +56,9 @@ def scan_image(image_name, image_remove: false)
 
   File.delete(File.join(out_path, 'result.json')) if File.exist?(File.join(out_path, 'result.json'))
   if which('trivy')
+    cmd.each_with_index do |_, i|
+      cmd[i].gsub!(%r{\./out}, out_path)
+    end
     system("trivy #{cmd.join(' ')}")
   else
     @trivy ||= Docker::Image.create('fromImage' => 'aquasec/trivy:latest')


### PR DESCRIPTION
An error occurs like bellow when specify `VOLUME_PATH` environment variable and trivy exists in execution environment.

```
2022-08-15T03:35:24.910Z	FATAL	flag error: report flag error: failed to create an output file: open ./out/result.json: no such file or directory
```

So, I fixed the path passed to the trivy's `--output` option.