### PR TITLE
Disable Trivy's secret scanning

### DIFF
--- a/funcs.rb
+++ b/funcs.rb
@@ -43,6 +43,8 @@ def scan_image(image_name, image_remove: false)
     '--no-progress',
     '-s',
     'HIGH,CRITICAL',
+    '--security-checks',
+    'vuln',
     '--format',
     'json',
     '--exit-code',


### PR DESCRIPTION
Trivy's secret scanning is enabled by default. But, it is slow and its results are not used now. So, disabling it will speed up the scan, I think.

- ref: [Scanning - Trivy](https://aquasecurity.github.io/trivy/v0.31.2/docs/secret/scanning/#recommendation)