### PR TITLE
Skip scan if image belongs to archived repository

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -57,6 +57,7 @@ config['orgs'].each do |o|
               id
               repository {
                 name
+                isArchived
               }
               versions(first: 1, orderBy: {field: CREATED_AT, direction: DESC}) {
                 nodes {
@@ -76,6 +77,7 @@ config['orgs'].each do |o|
     data.to_h[type]['packages']['edges'].each do |i|
       r = i['node']['repository']['name']
       next if i['node']['versions']['nodes'].empty?
+      next if i['node']['repository']['isArchived']
 
       begin
         imn = i['node']['name']


### PR DESCRIPTION
Skip scan if image belongs to archived repository. Archived repositories are read-only, so vulnerabilities cannot be fixed and cannot create issue when detected.

However, the images belong to archived repositories can be pulled and used. What do you think?