### PR TITLE
Use latest bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,4 +95,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.2
+   2.3.21


### PR DESCRIPTION
bundler 1.17.2 is vulnerable, and it is included in the Docker image.

- CVE-2019-3881
- CVE-2020-36327