### PR TITLE
notify only cvss critical

### DIFF
--- a/funcs.rb
+++ b/funcs.rb
@@ -42,7 +42,7 @@ def scan_image(image_name, image_remove: false)
     '--ignore-unfixed',
     '--no-progress',
     '-s',
-    'HIGH,CRITICAL',
+    'CRITICAL',
     '--security-checks',
     'vuln',
     '--format',


### PR DESCRIPTION
CVSS 8以下の値は影響がないと判断することがほとんどなので、報告対象から外す。